### PR TITLE
remove Exact from growth model names

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,11 +63,11 @@ Rules that simply transform the state of a single cell, ignoring the rest of the
 
 ```@docs
 GrowthRule
-ExactExponentialGrowth
-ExactLogisticGrowth
+ExponentialGrowth
+LogisticGrowth
 GrowthMapRule
-ExactExponentialGrowthMap
-ExactLogisticGrowthMap
+ExponentialGrowthMap
+LogisticGrowthMap
 MaskGrowthMap
 ```
 

--- a/src/Dispersal.jl
+++ b/src/Dispersal.jl
@@ -51,9 +51,9 @@ export AlleeExtinction, JumpDispersal, HumanDispersal
 
 export BatchGroups, HeirarchicalGroups
 
-export ExactExponentialGrowth, ExactLogisticGrowth
+export ExponentialGrowth, LogisticGrowth
 
-export MaskGrowthMap, ExactExponentialGrowthMap, ExactLogisticGrowthMap
+export MaskGrowthMap, ExponentialGrowthMap, LogisticGrowthMap
 
 export AuxCopy
 

--- a/src/rules/growth.jl
+++ b/src/rules/growth.jl
@@ -29,7 +29,7 @@ Simple fixed exponential growth rate using exact solution.
 
 $(FIELDDOCTABLE)
 """
-struct ExactExponentialGrowth{R,W,GR,TS,S} <: GrowthRule{R,W}
+struct ExponentialGrowth{R,W,GR,TS,S} <: GrowthRule{R,W}
     "Intrinsic rate of growth per timestep"
     intrinsicrate::GR
     "Timestep used in formulation"
@@ -37,17 +37,17 @@ struct ExactExponentialGrowth{R,W,GR,TS,S} <: GrowthRule{R,W}
     "The fractional number of rule timesteps in the current simulation timestep"
     nsteps::S
 end
-ExactExponentialGrowth{R,W}(;
+ExponentialGrowth{R,W}(;
     intrinsicrate=INTRINSICRATE,
     timestep=nothing,
     nsteps=1.0,
-) where {R,W} = ExactExponentialGrowth{R,W}(intrinsicrate, timestep, nsteps)
+) where {R,W} = ExponentialGrowth{R,W}(intrinsicrate, timestep, nsteps)
 
 # DynamicGrids.jl interface
 
-precalcrule(rule::ExactExponentialGrowth, data) = precalc_timestep(rule, data)
+precalcrule(rule::ExponentialGrowth, data) = precalc_timestep(rule, data)
 
-@inline function applyrule(data, rule::ExactExponentialGrowth, population, cellindex)
+@inline function applyrule(data, rule::ExponentialGrowth, population, cellindex)
     population > zero(population) || return zero(population)
     population * exp(rule.intrinsicrate * rule.nsteps)
 end
@@ -58,7 +58,7 @@ Simple fixed logistic growth rate using exact solution
 
 $(FIELDDOCTABLE)
 """
-struct ExactLogisticGrowth{R,W,CC,GR,TS,S} <: GrowthRule{R,W}
+struct LogisticGrowth{R,W,CC,GR,TS,S} <: GrowthRule{R,W}
     "Carrying capacity for each cell. Not currently scaled by area."
     carrycap::CC
     "Intrinsic rate of growth per timestep"
@@ -68,18 +68,18 @@ struct ExactLogisticGrowth{R,W,CC,GR,TS,S} <: GrowthRule{R,W}
     "The fractional number of rule timesteps in the current simulation timestep"
     nsteps::S
 end
-ExactLogisticGrowth{R,W}(;
+LogisticGrowth{R,W}(;
     carrycap=CARRYCAP,
     intrinsicrate=INTRINSICRATE,
     timestep=nothing,
     nsteps=1.0,
-    ) where {R,W} = ExactLogisticGrowth{R,W}(carrycap, intrinsicrate, timestep, nsteps)
+    ) where {R,W} = LogisticGrowth{R,W}(carrycap, intrinsicrate, timestep, nsteps)
 
 # DynamicGrids.jl interface
 
-precalcrule(rule::ExactLogisticGrowth, data) = precalc_timestep(rule, data)
+precalcrule(rule::LogisticGrowth, data) = precalc_timestep(rule, data)
 
-@inline function applyrule(data, rule::ExactLogisticGrowth, population, cellindex)
+@inline function applyrule(data, rule::LogisticGrowth, population, cellindex)
     population > zero(population) || return zero(population)
     @fastmath (population * rule.carrycap) / (population + (rule.carrycap - population) *
                                          exp(-rule.intrinsicrate * rule.nsteps))
@@ -92,7 +92,7 @@ Exponential growth based on a growth rate data, using exact solution.
 
 $(FIELDDOCTABLE)
 """
-struct ExactExponentialGrowthMap{R,W,AK<:Val,AT,TS,S} <: GrowthMapRule{R,W}
+struct ExponentialGrowthMap{R,W,AK<:Val,AT,TS,S} <: GrowthMapRule{R,W}
     "Key for aux data"
     auxkey::AK
     "Precalculated time interpolation index for aux data"
@@ -102,21 +102,21 @@ struct ExactExponentialGrowthMap{R,W,AK<:Val,AT,TS,S} <: GrowthMapRule{R,W}
     "The fractional number of rule timesteps in the current simulation timestep"
     nsteps::S
 end
-ExactExponentialGrowthMap{R,W}(;
+ExponentialGrowthMap{R,W}(;
     auxkey,
     auxtimeindex=1,
     timestep=nothing,
     nsteps=1.0,
-) where {R,W} = ExactExponentialGrowthMap{R,W}(auxkey, auxtimeindex, timestep, nsteps)
+) where {R,W} = ExponentialGrowthMap{R,W}(auxkey, auxtimeindex, timestep, nsteps)
 
 # DynamicGrids.jl interface
 
-function precalcrule(rule::ExactExponentialGrowthMap, data)
+function precalcrule(rule::ExponentialGrowthMap, data)
     rule = precalc_timestep(rule, data)
     precalc_auxtimeindex(aux(data, rule.auxkey), rule, data)
 end
 
-@inline function applyrule(data, rule::ExactExponentialGrowthMap, population, cellindex)
+@inline function applyrule(data, rule::ExponentialGrowthMap, population, cellindex)
     population > zero(population) || return zero(population)
     intrinsicrate = auxval(data, rule.auxkey, cellindex..., rule.auxtimeindex) 
     @fastmath population * exp(intrinsicrate * rule.nsteps)
@@ -129,7 +129,7 @@ Logistic growth based on a growth rate layer, using exact solution.
 Saturation only applies with positive growth
 $(FIELDDOCTABLE)
 """
-struct ExactLogisticGrowthMap{R,W,AK<:Val,AT,CC,TS,S} <: GrowthMapRule{R,W}
+struct LogisticGrowthMap{R,W,AK<:Val,AT,CC,TS,S} <: GrowthMapRule{R,W}
     "Key for aux layer"
     auxkey::AK
     "Precalculated time interpolation index for aux data"
@@ -141,22 +141,22 @@ struct ExactLogisticGrowthMap{R,W,AK<:Val,AT,CC,TS,S} <: GrowthMapRule{R,W}
     "The fractional number of rule timesteps in the current simulation timestep"
     nsteps::S
 end
-ExactLogisticGrowthMap{R,W}(;
+LogisticGrowthMap{R,W}(;
     auxkey,
     auxtimeindex=:1,
     carrycap=CARRYCAP,
     timestep=nothing,
     nsteps=1.0,
-) where {R,W} = ExactLogisticGrowthMap{R,W}(auxkey, auxtimeindex, carrycap, timestep, nsteps)
+) where {R,W} = LogisticGrowthMap{R,W}(auxkey, auxtimeindex, carrycap, timestep, nsteps)
 
 # DynamicGrids.jl interface
 
-function precalcrule(rule::ExactLogisticGrowthMap, data)
+function precalcrule(rule::LogisticGrowthMap, data)
     rule = precalc_timestep(rule, data)
     precalc_auxtimeindex(aux(data, rule.auxkey), rule, data)
 end
 
-@inline function applyrule(data, rule::ExactLogisticGrowthMap, population, cellindex)
+@inline function applyrule(data, rule::LogisticGrowthMap, population, cellindex)
     population > zero(population) || return zero(population)
     intrinsicrate = auxval(data, rule.auxkey, cellindex..., rule.auxtimeindex) 
     if intrinsicrate > zero(intrinsicrate)

--- a/test/optimisation/optimisation.jl
+++ b/test/optimisation/optimisation.jl
@@ -30,7 +30,7 @@ end
     ngroups = 1
     groupsize = 1
     rate = log(2.0)
-    ruleset = Ruleset(ExactExponentialGrowth(intrinsicrate=rate))
+    ruleset = Ruleset(ExponentialGrowth(intrinsicrate=rate))
     output = ArrayOutput(init; tspan=tspan)
     sim!(output, ruleset)
 
@@ -85,7 +85,7 @@ end
 
     objective = RegionObjective(detectionthreshold, regionlookup, occurance, framesperstep, 1)
     output = RegionOutput(init; tspan=tspan, objective=objective)
-    ruleset = Ruleset(ExactExponentialGrowth(intrinsicrate = log(2.0)))
+    ruleset = Ruleset(ExponentialGrowth(intrinsicrate = log(2.0)))
     loss = ZeroOneLoss()
 
     @testset "SingleCoreReplicates" begin

--- a/test/optimisation/output.jl
+++ b/test/optimisation/output.jl
@@ -19,7 +19,7 @@ framesperstep = 2
 objective = RegionObjective(detectionthreshold, regionlookup, occurance, framesperstep, start)
 
 @testset "region output works" begin
-    rule = ExactExponentialGrowth(intrinsicrate = log(2.0))
+    rule = ExponentialGrowth(intrinsicrate = log(2.0))
     output = RegionOutput(init; objective=objective, tspan=1:5)
     sim!(output, rule)
 end

--- a/test/rules/growth.jl
+++ b/test/rules/growth.jl
@@ -18,7 +18,7 @@ using Unitful: d
              12.0 24.0 36.0]
 
     output = ArrayOutput(init; tspan=1:3)
-    rule = Ruleset(ExactExponentialGrowth(intrinsicrate=log(2.0)))
+    rule = Ruleset(ExponentialGrowth(intrinsicrate=log(2.0)))
     sim!(output, rule)
 
     @test output[1] == test1
@@ -26,7 +26,7 @@ using Unitful: d
     @test output[3] == test3
 
     output = ArrayOutput(init; tspan=1d:1d:3d)
-    rule = Ruleset(ExactExponentialGrowth(intrinsicrate=log(2.0), timestep=1d); timestep=1d)
+    rule = Ruleset(ExponentialGrowth(intrinsicrate=log(2.0), timestep=1d); timestep=1d)
     sim!(output, rule)
 
     @test output[1] == test1
@@ -34,7 +34,7 @@ using Unitful: d
     @test output[3] == test3
 
     output = ArrayOutput(init; tspan=DateTime(2001,1,1):Day(5):DateTime(2001,1,15))
-    rule = Ruleset(ExactExponentialGrowth(intrinsicrate=log(2.0)/5, timestep=Day(1)); timestep=Day(5))
+    rule = Ruleset(ExponentialGrowth(intrinsicrate=log(2.0)/5, timestep=Day(1)); timestep=Day(5))
     sim!(output, rule)
 
     @test output[1] == test1
@@ -53,7 +53,7 @@ end
 
     output = ArrayOutput(init; tspan=1:3, aux=(suit=suit,))
     output.extent
-    rule = Ruleset(ExactExponentialGrowthMap(auxkey=Val(:suit)))
+    rule = Ruleset(ExponentialGrowthMap(auxkey=Val(:suit)))
     sim!(output, rule)
 
     @test output[1] == [1.0 1.0 1.0;
@@ -90,7 +90,7 @@ end
              5.0      8.0      9.41176;
              6.31579  8.57143  9.72973]
 
-    rule = Ruleset(ExactLogisticGrowth(intrinsicrate=log(2.0), carrycap=10))
+    rule = Ruleset(LogisticGrowth(intrinsicrate=log(2.0), carrycap=10))
     output = ArrayOutput(init; tspan=1:3)
 
     sim!(output, rule)
@@ -123,7 +123,7 @@ end
                   1.0 1.0 0.5])
 
     output = ArrayOutput(init; tspan=1:3, aux=(suit=suit,))
-    rule = Ruleset(ExactLogisticGrowthMap(auxkey=Val(:suit), carrycap=10))
+    rule = Ruleset(LogisticGrowthMap(auxkey=Val(:suit), carrycap=10))
     sim!(output, rule)
 
     @test output[1] == test1

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -32,7 +32,7 @@ suitseq = DimensionalArray(a, dimz)
 init = zero(suitseq)
 
 @testset "sequence of layers" begin
-    rule = ExactExponentialGrowthMap(; auxkey=Val(:suit))
+    rule = ExponentialGrowthMap(; auxkey=Val(:suit))
     ruleset = Ruleset(rule; timestep=1d)
     data = SimData(Extent(init=init, aux=(suit=suitseq,), tspan=1:1), ruleset)
 


### PR DESCRIPTION
Removes the "Exact" from the start of e.g. "ExactLogisticGrowth"

Closes #51 