### PR TITLE
cleanup rule syntax

### DIFF
--- a/src/allee.jl
+++ b/src/allee.jl
@@ -17,7 +17,8 @@ end
 AlleeExtinction{R,W}(; minfounders=Param(5.0, bounds=(1.0, 200.0))) where {R,W} = 
     AlleeExtinction{R,W}(minfounders)
 
-@inline function applyrule(data, rule::AlleeExtinction, state, I)
-    minfounders = get(data, rule.minfounders, I...)
-    state >= minfounders ? state : zero(state)
+@inline function applyrule(data, rule::AlleeExtinction, N, I)
+    f = get(data, rule.minfounders, I...)
+
+    return N >= f ? N : zero(N)
 end

--- a/src/growth.jl
+++ b/src/growth.jl
@@ -38,9 +38,9 @@ precalcrule(rule::ExponentialGrowth, data) = precalc_timestep(rule, data)
 
 @inline function applyrule(data, rule::ExponentialGrowth, N, I)
     N > zero(N) || return zero(N)
-    r = get(data, rule.rate, I...) * rule.nsteps
+    rt = get(data, rule.rate, I...) * rule.nsteps
 
-    return @fastmath N * exp(r)
+    return @fastmath N * exp(rt)
 end
 
 """
@@ -79,13 +79,13 @@ precalcrule(rule::LogisticGrowth, data) = precalc_timestep(rule, data)
 @inline function applyrule(data, rule::LogisticGrowth, N, I)
     N > zero(N) || return zero(N)
 
-    r = get(data, rule.rate, I...) * rule.nsteps 
+    rt = get(data, rule.rate, I...) * rule.nsteps 
     k = get(data, rule.carrycap, I...) 
 
-    if r > zero(r)
-        return @fastmath (N * k) / (N + (k - N) * exp(-r))
+    if rt > zero(rt)
+        return @fastmath (N * k) / (N + (k - N) * exp(-rt))
     else
-        return @fastmath N * exp(r)
+        return @fastmath N * exp(rt)
     end
 end
 

--- a/src/human.jl
+++ b/src/human.jl
@@ -163,7 +163,7 @@ function alloc_gravities(human, nshortlisted)
         gravities[i, j] = Gravity(0.0f0, (i, j))
     end
     gravity_vector = deepcopy(vec(gravities))
-    gravities, gravity_vector
+    return gravities, gravity_vector
 end
 
 # Precalculate a dispersal shortlist for each cell
@@ -185,6 +185,7 @@ function precalc_human_dispersal!(
     Threads.@threads for j in 1:size(human_buffer, 2)
         precalc_col!(dest_shortlists, nshortlisted, human_buffer, distances, thread_alloc, j)
     end
+    return dest_shortlists
 end
 
 # Raise the human population/activity matrix to some exponent
@@ -211,12 +212,13 @@ function precalc_col!(dest_shortlists, nshortlisted, human, distances, thread_al
     for i = 1:size(human, 1)
         precalc_cell!(dest_shortlists, nshortlisted, human, distances, col_alloc, i, j)
     end
+    return nothing
 end
 
 function precalc_cell!(dest_shortlists, nshortlisted, human, distances, (gravities, gravity_vector), i, j)
     if ismissing(human[i, j])
         dest_shortlists[i, j] = missing
-        return
+        return nothing
     end
     # Calculate the gravity for all cells in the grid
     assign_gravities!(gravities, human, distances, i, j)
@@ -227,6 +229,7 @@ function precalc_cell!(dest_shortlists, nshortlisted, human, distances, (graviti
     gravity_shortlist = view(gravity_vector, 1:nshortlisted)
     # Convert shortlies gravities to intervals
     gravity2inverval!(dest_shortlists[i, j], gravity_shortlist)
+    return nothing
 end
 
 # Calculate the gravity for all cells in the grid
@@ -241,6 +244,7 @@ function assign_gravities!(gravities, human, distances, i, j)
             (human[ii, jj] / distances[celldist...])
         end
     end
+    return gravities
 end
 
 # Convert the gravity of a cell to an interval than can
@@ -269,9 +273,9 @@ end
 # DynamicGrids Interface ###################################################
 
 @inline function applyrule!(data, rule::HumanDispersal{R,W}, N, I) where {R,W}
-    N == zero(N) && return
+    N == zero(N) && return nothing
     dispersalprob = rule.human_pop[I...] * rule.dispersalperpop
-    ismissing(dispersalprob) && return
+    ismissing(dispersalprob) && return nothing
     shortlist = rule.dest_shortlists[downsample_index(I, rule.scale)...]
     #ismissing(shortlist) && return
 
@@ -283,7 +287,7 @@ end
         data[W], mode(rule), rule, shortlist, dispersalprob, N, I
     )
     add!(data[W], -dispersed, I...)
-    return 
+    return nothing
 end
 
 
@@ -341,13 +345,13 @@ function disperse2dest!(data::DG.WritableGridData, rule, shortlist, maybedispers
     upsample = upsample_index(shortlist[dest_id].index, rule.scale)
     dest_index = upsample .+ (rand(0:rule.scale-1), rand(0:rule.scale-1))
     # Skip dispsal to upsampled dest cells that are masked or out of bounds, and try again
-    return if !DynamicGrids.ismasked(data, dest_index...) &&
+    if !DynamicGrids.ismasked(data, dest_index...) &&
         DynamicGrids.isinbounds(dest_index, data)
         # Disperse to the cell.
         add!(data, maybedispersing, dest_index...)
-        maybedispersing
+        return maybedispersing
     else
-        zero(maybedispersing)
+        return zero(maybedispersing)
     end
 end
 

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -24,21 +24,20 @@ function JumpDispersal{R,W}(;
     JumpDispersal{R,W}(prob_threshold, spotrange)
 end
 
-@inline function applyrule!(data, rule::JumpDispersal{R,W}, state, I) where {R,W}
+@inline function applyrule!(data, rule::JumpDispersal{R,W}, N, I) where {R,W}
     # Ignore empty cells
-    state > zero(state) || return state
+    N > zero(N) || return N
     # Random dispersal events
-    prob_threshold = get(data, rule.prob_threshold, I...) 
-    rand() < prob_threshold || return state
+    p = get(data, rule.prob_threshold, I...) 
+    rand() < p || return N
 
     # Randomly select spotting distance
     intspot = round(Int, rule.spotrange)
     rnge = -intspot:intspot
-    jump = (rand(rnge), rand(rnge))
-    jumpdest, is_inbounds = inbounds(jump .+ I, data)
+    dest, is_inbounds = inbounds((rand(rnge), rand(rnge)) .+ I, data)
 
     # Update spotted cell if it's on the grid
-    is_inbounds && @inbounds add!(data[W], state, jumpdest...)
+    is_inbounds && @inbounds add!(data[W], N, dest...)
 
-    return state
+    return nothing
 end

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -26,10 +26,10 @@ end
 
 @inline function applyrule!(data, rule::JumpDispersal{R,W}, N, I) where {R,W}
     # Ignore empty cells
-    N > zero(N) || return N
+    N > zero(N) || return nothing
     # Random dispersal events
     p = get(data, rule.prob_threshold, I...) 
-    rand() < p || return N
+    rand() < p || return nothing
 
     # Randomly select spotting distance
     intspot = round(Int, rule.spotrange)

--- a/src/kernel/inwards.jl
+++ b/src/kernel/inwards.jl
@@ -25,5 +25,4 @@ function InwardsDispersal{R,W}(; neighborhood=DispersalKernel{3}()) where {R,W}
     InwardsDispersal{R,W}(neighborhood)
 end
 
-@inline applyrule(data, rule::InwardsDispersal, state, I) = 
-    LinearAlgebra.dot(neighborhood(rule))
+@inline applyrule(data, rule::InwardsDispersal, N, I) = dot(neighborhood(rule))

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -28,7 +28,7 @@ function OutwardsDispersal{R,W}(; neighborhood=DispersalKernel{3}()) where {R,W}
 end
 
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
-    N == zero(N) && return
+    N == zero(N) && return nothing
     sum = zero(N)
     for (i, offset) in enumerate(offsets(rule))
         @inbounds propagules = N * kernel(rule)[i]

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -27,15 +27,14 @@ function OutwardsDispersal{R,W}(; neighborhood=DispersalKernel{3}()) where {R,W}
     OutwardsDispersal{R,W}(neighborhood)
 end
 
-@inline function applyrule!(data, rule::OutwardsDispersal{R,W}, state, I) where {R,W}
-    state == zero(state) && return
-    sum = zero(state)
+@inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
+    N == zero(N) && return
+    sum = zero(N)
     for (i, offset) in enumerate(offsets(rule))
-        @inbounds propagules = state * kernel(rule)[i]
+        @inbounds propagules = N * kernel(rule)[i]
         @inbounds add!(data[W], propagules, I .+ offset...)
         sum += propagules
     end
-    # Subtract from current cell, unless state is Bool
-    state isa Bool || @inbounds sub!(data[W], sum, I...)
+    @inbounds sub!(data[W], sum, I...)
     return nothing
 end


### PR DESCRIPTION
## Description

This PR is proposing a simpler more mathy syntax to use for rules. After writing the paper I realise it's a lot easier to read. Nothing is changed logically except some unused return values for `applyrule!` that needed change with this syntax, but should be `nothing`, not `state` or `N`.

So: I've used `N` everywhere to represent populations, as in classic growth formulas. Rates are represented with `r`. Carrying capacity is `k`. But in the structs they have the full name, so the code self documents instead of being indecipherable math:

```julia
k = get(data, rule.carrycap, I...) 
```

Also, `I` is for the cell index, following Julia standard syntax for a tuple of indices.

@virgile-baudrot we are moving to having code review of any changes in Dispersal.jl so that no one person is totally responsible for formulations being correct (me right now). These are just minor issues with no actual changes to get that started. But In future formulations should all be reviewed by someone else before they are merged, not that we will add or change things here very often.

## Checklist:

- [x] My code follows the [BlueStyle](https://github.com/invenia/BlueStyle) style guide
- [ ] ~My code is commented with explanations of anything hard to understand~ (there is no new code added here)
- [x] There are no unnecessary or unrelated code changes included in this PR
- [x] There are no depencecies added: if so, please consider if they are necessary and explain why they are required
