### PR TITLE
rethink nsteps for clarity and type stability

### DIFF
--- a/src/growth.jl
+++ b/src/growth.jl
@@ -13,9 +13,9 @@ abstract type GrowthRule{R,W} <: CellRule{R,W} end
 """
     ExponentialGrowth <: CellRule
 
-    ExponentialGrowth(; rate, timestep)
-    ExponentialGrowth{R}(; rate, timestep)
-    ExponentialGrowth{R,W}(; rate, timestep)
+    ExponentialGrowth(; rate, timestep, [nsteps_type])
+    ExponentialGrowth{R}(; rate, timestep, [nsteps_type])
+    ExponentialGrowth{R,W}(; rate, timestep, [nsteps_type])
 
 Exponential growth of population size N based on an intrinsic growth rate ``r``, using the
 exact solution between timesteps ``t`` and ``t-1``:
@@ -27,7 +27,10 @@ N_t = N_{t-1}e^{r t}
 # Keywords
 
 - `rate`: Intrinsic growth rate. May be a `Number`, an `Aux` array or another `Grid`.
-- `timestep`: Time step for the growth rate calculation, in a type compatible with the simulation `tspan`.
+- `timestep`: Time step for the growth rate calculation, in a type compatible with the 
+    simulation `tspan`.
+- `nsteps_type`: Specify the floating point type to use when `nsteps` is generated from the
+    timestep, if it is required for type-stability or performance. The default is `Float64`.
 
 Pass grid `Symbol`s to `R` or both `R` and `W` type parameters to use to specific grids.
 """
@@ -36,14 +39,15 @@ struct ExponentialGrowth{R,W,GR,TS,S} <: GrowthRule{R,W}
     timestep::TS
     nsteps::S
 end
-function ExponentialGrowth{R,W}(; 
-    rate=INTRINSICRATE_PARAM, 
-    timestep, 
+function ExponentialGrowth{R,W}(;
+    rate=INTRINSICRATE_PARAM,
+    timestep,
+    nsteps_type=Float64,
 ) where {R,W}
-    ExponentialGrowth{R,W}(rate, timestep, nothing)
+    ExponentialGrowth{R,W}(rate, timestep, zero(nsteps_type))
 end
 
-modifyrule(rule::ExponentialGrowth, data) = precalc_timestep(rule, data)
+modifyrule(rule::ExponentialGrowth, data) = precalc_nsteps(rule, data)
 
 @inline function applyrule(data, rule::ExponentialGrowth, N, I)
     N > zero(N) || return zero(N)
@@ -55,9 +59,9 @@ end
 """
     LogisticGrowth <: GrowthRule
 
-    LogisticGrowth(; rate, carrycap, timestep)
-    LogisticGrowth{R}(; rate, carrycap, timestep)
-    LogisticGrowth{R,W}(; rate, carrycap, timestep)
+    LogisticGrowth(; rate, carrycap, timestep, [nsteps_type])
+    LogisticGrowth{R}(; rate, carrycap, timestep, [nsteps_type])
+    LogisticGrowth{R,W}(; rate, carrycap, timestep, [nsteps_type])
 
 Logistic growth rate of population size ``N`` based on an intrinsic growth rate ``r`` and
 carry capacity ``K``, using the exact solution between timesteps ``t+1`` and ``t``:
@@ -73,8 +77,9 @@ These may be a `Number`, an `Aux` array or another `Grid`:
 
 - `rate`: Intrinsic growth rate.
 - `carrycap`: Carrying capacity.
-
 - `timestep`: Time step for the growth rate, in a type compatible with the simulation `tspan`.
+- `nsteps_type`: Specify the floating point type to use when `nsteps` is generated from the
+    timestep, if it is required for type-stability or performance. The default is `Float64`.
 
 Pass grid `Symbol`s to `R` or both `R` and `W` type parameters to use to specific grids.
 """
@@ -85,20 +90,21 @@ struct LogisticGrowth{R,W,GR,CC,TS,S} <: GrowthRule{R,W}
     nsteps::S
 end
 function LogisticGrowth{R,W}(;
-    rate=INTRINSICRATE_PARAM, 
-    carrycap=CARRYCAP_PARAM, 
-    timestep, 
+    rate=INTRINSICRATE_PARAM,
+    carrycap=CARRYCAP_PARAM,
+    timestep,
+    nsteps_type=Float64,
 ) where {R,W}
-    LogisticGrowth{R,W}(rate, carrycap, timestep, nothing)
+    LogisticGrowth{R,W}(rate, carrycap, timestep, zero(nsteps_type))
 end
 
-modifyrule(rule::LogisticGrowth, data) = precalc_timestep(rule, data)
+modifyrule(rule::LogisticGrowth, data) = precalc_nsteps(rule, data)
 
 @inline function applyrule(data, rule::LogisticGrowth, N, I)
     N > zero(N) || return zero(N)
 
-    rt = get(data, rule.rate, I...) * rule.nsteps 
-    k = get(data, rule.carrycap, I...) 
+    rt = get(data, rule.rate, I...) * rule.nsteps
+    k = get(data, rule.carrycap, I...)
 
     if rt > zero(rt)
         return @fastmath (N * k) / (N + (k - N) * exp(-rt))
@@ -111,7 +117,7 @@ end
     ThresholdGrowth <: CellRule
 
     ThresholdGrowth(; rate, threshold)
-    ThresholdGrowth{G}(; rate, threshold)
+    ThresholdGrowth{R}(; rate, threshold)
     ThresholdGrowth{R,W}(; rate, threshold)
 
 Simple threshold mask. Values below a certain threshold are replaced with zero.
@@ -120,8 +126,8 @@ Simple threshold mask. Values below a certain threshold are replaced with zero.
 
 These may be a `Number`, an `Aux` array or another `Grid`.
 
-- `rate`: Intrinsic growth rate. 
-- `threshold`: Minimum viability threshold below which population falls to zero.  
+- `rate`: Intrinsic growth rate.
+- `threshold`: Minimum viability threshold below which population falls to zero.
 
 Pass grid `Symbol`s to `R` or both `R` and `W` type parameters to use to specific grids.
 """
@@ -129,8 +135,8 @@ struct ThresholdGrowth{R,W,GR,Th} <: GrowthRule{R,W}
     rate::GR
     threshold::Th
 end
-function ThresholdGrowth{R,W}(; 
-    rate=INTRINSICRATE_PARAM, 
+function ThresholdGrowth{R,W}(;
+    rate=INTRINSICRATE_PARAM,
     threshold=THRESHOLD_PARAM,
 ) where {R,W}
     ThresholdGrowth{R,W}(rate, threshold)
@@ -143,7 +149,8 @@ end
     return r >= t ? N : zero(N)
 end
 
-precalc_timestep(rule, data) = precalc_timestep(rule.timestep, rule, data)
-precalc_timestep(rulestep::DatePeriod, rule, data) =
-    @set rule.nsteps = currenttimestep(data) / Millisecond(rulestep)
-precalc_timestep(rulestep, rule, data) = @set rule.nsteps = timestep(data) / rulestep
+precalc_nsteps(rule, data) = precalc_nsteps(rule.timestep, rule, data)
+precalc_nsteps(rulestep::DatePeriod, rule, data) =
+    @set rule.nsteps = typeof(rule.nsteps)(currenttimestep(data) / Millisecond(rulestep))
+precalc_nsteps(rulestep, rule, data) =
+    @set rule.nsteps = typeof(rule.nsteps)(timestep(data) / rulestep)

--- a/src/mortality.jl
+++ b/src/mortality.jl
@@ -46,11 +46,12 @@ function LoglogisticMortality{R,W}(;
     median=MEDIAN_LOGLOGISTIC,
     hillcoefficient=HILLCOEFFICIENT,
     timestep,
+    nsteps_type=Float64,
 ) where {R,W}
-    LoglogisticMortality{R,W}(median, hillcoefficient, timestep, nothing)
+    LoglogisticMortality{R,W}(median, hillcoefficient, timestep, zero(nsteps_type))
 end
 
-modifyrule(rule::LoglogisticMortality, data) = precalc_timestep(rule, data)
+modifyrule(rule::LoglogisticMortality, data) = precalc_nsteps(rule, data)
 
 @inline function applyrule(data, rule::LoglogisticMortality, (N, X), I)
     N > zero(N) || return zero(N)
@@ -99,8 +100,9 @@ function ExponentialMortality{R,W}(;
     rate=INTRINSICRATE_PARAM,
     threshold=THRESHOLD_EXPOSURE,
     timestep, 
+    nsteps_type=Float64,
 ) where {R,W}
-    ExponentialMortality{R,W}(rate, threshold, timestep, nothing)
+    ExponentialMortality{R,W}(rate, threshold, timestep, zero(nsteps_type))
 end
 
 modifyrule(rule::ExponentialMortality, data) = precalc_nsteps(rule, data)

--- a/src/mortality.jl
+++ b/src/mortality.jl
@@ -14,9 +14,9 @@ abstract type Mortality{R,W} <: CellRule{R,W} end
 """
     LoglogisticMortality <: Mortality
 
-    LoglogisticMortality(; median, hillcoefficient, timestep)
-    LoglogisticMortality{R}(; median, hillcoefficient, timestep)
-    LoglogisticMortality{R,W}(; median, hillcoefficient, timestep)
+    LoglogisticMortality(; median, hillcoefficient, timestep, [nsteps_type])
+    LoglogisticMortality{R}(; median, hillcoefficient, timestep, [nsteps_type])
+    LoglogisticMortality{R,W}(; median, hillcoefficient, timestep, [nsteps_type])
 
 Loglogistic mortality based on median, ``α`` and hill coefficient ``β``.
 
@@ -63,9 +63,9 @@ end
 """
     ExponentialMortality <: Mortality
 
-    ExponentialMortality(; rate, threshold, timestep)
-    ExponentialMortality{R}(; rate, threshold, timestep)
-    ExponentialMortality{R,W}(; rate, threshold, timestep)
+    ExponentialMortality(; rate, threshold, timestep, [nsteps_type])
+    ExponentialMortality{R}(; rate, threshold, timestep, [nsteps_type])
+    ExponentialMortality{R,W}(; rate, threshold, timestep, [nsteps_type])
 
 Exponential mortality based on exposure threshold and mortality rate parameter, using exact solution.
 
@@ -81,6 +81,8 @@ N_{t+1} = N_{t}e^{-r t(X-z)}
 - `rate`: Mortality rate.
 - `threshold`: Exposure threshold under which there is no effect.
 - `timestep`: Time step for the growth rate, in a type compatible with the simulation `tspan`.
+- `nsteps_type`: Specify the floating point type to use when `nsteps` is generated from the
+    timestep, if it is required for type-stability or performance. The default is `Float64`.
 
 `rate` and `threshold` can be a `Number`, an `Aux` array or another Grid`.
 
@@ -101,7 +103,7 @@ function ExponentialMortality{R,W}(;
     ExponentialMortality{R,W}(rate, threshold, timestep, nothing)
 end
 
-modifyrule(rule::ExponentialMortality, data) = precalc_timestep(rule, data)
+modifyrule(rule::ExponentialMortality, data) = precalc_nsteps(rule, data)
 
 @inline function applyrule(data, rule::ExponentialMortality, (N,X), I)
     N > zero(N) || return zero(N)

--- a/test/growth.jl
+++ b/test/growth.jl
@@ -44,33 +44,33 @@ using Unitful: d
 end
 
 @testset "exponential growth with rate from growth map" begin
-    init = [1.0 1.0 1.0;
-            1.0 1.0 1.0;
-            1.0 1.0 1.0]
+    init = Float32[1.0 1.0 1.0;
+                   1.0 1.0 1.0;
+                   1.0 1.0 1.0]
 
-    suit =  log.([1.0 1.0 2.0;
-                  2.0 1.0 0.5;
-                  1.0 1.0 0.5])
+    suit =  log.(Float32[1.0 1.0 2.0;
+                         2.0 1.0 0.5;
+                         1.0 1.0 0.5])
 
     output = ArrayOutput(init; tspan=1:3, aux=(suit=suit,))
     output.extent
-    rule = Ruleset(ExponentialGrowth(rate=Aux(:suit), timestep=1))
+    rule = Ruleset(ExponentialGrowth(rate=Aux(:suit), timestep=1, nsteps_type=Float32))
     sim!(output, rule)
 
-    @test output[1] == [1.0 1.0 1.0;
-                        1.0 1.0 1.0;
-                        1.0 1.0 1.0]
-    @test output[2] ≈  [1.0 1.0 2.0;
-                        2.0 1.0 0.5;
-                        1.0 1.0 0.5]
-    @test output[3] ≈  [1.0 1.0 4.0;
-                        4.0 1.0 0.25;
-                        1.0 1.0 0.25]
+    @test output[1] == Float32[1.0 1.0 1.0;
+                               1.0 1.0 1.0;
+                               1.0 1.0 1.0]
+    @test output[2] ≈  Float32[1.0 1.0 2.0;
+                               2.0 1.0 0.5;
+                               1.0 1.0 0.5]
+    @test output[3] ≈  Float32[1.0 1.0 4.0;
+                               4.0 1.0 0.25;
+                               1.0 1.0 0.25]
 
-    @test DynamicGrids.normalise.(output[3], 0.25, 4) == [0.2  0.2  1.0;
-                                                          1.0  0.2  0.0;
-                                                          0.2  0.2  0.0]
-
+    @test DynamicGrids.normalise.(output[3], 0.25f0, 4) == Float32[0.2 0.2 1.0;
+                                                                   1.0 0.2 0.0;
+                                                                   0.2 0.2 0.0]
+    @test isinferred(output, rule)
 end
 
 @testset "logistic growth" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,5 @@ end
 @time @safetestset "kernels" begin include("kernels.jl") end
 @time @safetestset "allee effects" begin include("allee.jl") end
 @time @safetestset "growth" begin include("growth.jl") end
+@time @safetestset "mortality" begin include("mortality.jl") end
 @time @safetestset "integration" begin include("integration.jl") end


### PR DESCRIPTION
# Description

This PR makes some small changes to growth `nsteps` precalculation. The main reason was that it was not type-stable in `Float32` because there was no way of setting the type of `nsteps`. Now instead of being able to set nsteps at all, (which doesn't make sense, it's precalculated for every frame)) you can use the keyword `nsteps_type` to set the type to `Float32` if you need the performance. 

Also renamed the `precalc_timestep` method to `precalc_nsteps`, as `nsteps` is precalculated, and the `timestep` is fixed.

It shouldn't be breaking syntax as no constructors should have been setting `nsteps` before anyway, as it did nothing.

## Changes:

- [ ] New formulation/rule
- [ ] Documentation
- [x] Bug fix for existing rules (non-breaking syntax)
- [ ] Major change to existing rules (breaking syntax, needs a breaking version bump)

# Checklist:

- [x] My code follows the [BlueStyle](https://github.com/invenia/BlueStyle) style guide
- [ ] My code is commented with explanations of anything hard to understand
- [x] There are no unnecessary or unrelated code changes included in this PR
- [x] There are no depencecies added: if so, please consider if they are necessary and explain why they are required

### For bugfixes

- [x] My PR addresses a single bug/connected group of bugs
- [x] I have included a test that will ensure the bug does not recur

### For new `Rule`s

- [ ] My PR is limited to a clear theme/cenceptual unit. (Otherwise make multiple PRs that can be discussed separately)
- [ ] New rules have tests in a file of the same name as the rule file, e.g. `/test/newrulename.jl`
- [ ] I have cited the source of the new formulation/s, if applicable
- [ ] I have added a documentation string to formulation struct/s, and added an entry in the docs

