### PR TITLE
propose_docs_example

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,20 @@
 - [ ] New rules have tests in a file of the same name as the rule file, e.g. `/test/newrulename.jl`
 - [ ] I have cited the source of the new formulation/s, if applicable
 - [ ] I have added a documentation string to formulation struct/s, and added an entry in the docs
-
+- [ ] The doc string has an Example block using `jldoctest`, like :
+    ````
+    """
+        TheRule <: CellRule
+    
+    Rest of the docs...
+    
+    # Example
+    
+    In this example we do...
+    ```jldoctest
+    rule = TheRule(; params...)
+    output = SomeOutput(; init=the_init_grid, tspan=the_tspan)
+    sim!(output, rule);
+    ```
+    """
+    ````


### PR DESCRIPTION
# Description

Having runnable examples for all rules would probably help new users a lot. It might require some thought to make it an interesting enough example that they learn something from it. e.g. `AlleeExtinction` is pretty boring on its own.

This PR updates the docs guidelines to enforce adding examples from now on. Which will also require updating all the existing rules.