### PR TITLE
Fixing boundary checks on masked grids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.jl.*.cov
 *.jl.mem
 docs/build
+*.json
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Distributions = "0.21, 0.22, 0.23, 0.24, 0.25"
 DocStringExtensions = "0.8, 0.9"
 DynamicGrids = "0.21"
 Reexport = "0.2, 1.0"
+Stencils = "0.3"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ DynamicGrids = "a5dba43e-3abc-5203-bfc5-584ca68d3f5b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Stencils = "264155e8-78a8-466a-aa59-c9b28c34d21a"
 
 [compat]
 Distributions = "0.21, 0.22, 0.23, 0.24, 0.25"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,7 +36,6 @@ AlleeExtinction
 ```@docs
 InwardsDispersal
 OutwardsDispersal
-OutwardsDispersalWithMask
 ```
 
 ### Dispersal kernels 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,6 +36,7 @@ AlleeExtinction
 ```@docs
 InwardsDispersal
 OutwardsDispersal
+OutwardsDispersalWithMask
 ```
 
 ### Dispersal kernels 

--- a/src/Dispersal.jl
+++ b/src/Dispersal.jl
@@ -16,6 +16,7 @@ using DynamicGrids.ModelParameters
 using DynamicGrids.Setfield
 using DynamicGrids.Stencils
 using DynamicGrids.StaticArrays
+using Stencils
 
 using DynamicGrids.ModelParameters: params
 

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -34,36 +34,29 @@ Pass grid name `Symbol`s to `R` and `W` type parameters to use specific grids.
 """
 struct OutwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil} <: SetNeighborhoodRule{R,W}
     stencil::S
+    mask::Union{Nothing, Array{Bool}}  # Add an optional mask parameter
 end
+
 function OutwardsDispersal{R,W}(; kw...) where {R,W}
-    OutwardsDispersal{R,W}(DispersalKernel(; kw...))
+    OutwardsDispersal{R,W}(DispersalKernel(; kw...), nothing)
 end
+
+# @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
+#     N == zero(N) && return nothing
+#     sum = zero(N)
+#     for (offset, k) in zip(offsets(rule), kernel(rule))
+#         @inbounds propagules = N * k
+#         @inbounds add!(data[W], propagules, I .+ offset...)
+#         sum += propagules
+#     end
+#     @inbounds sub!(data[W], sum, I...)
+#     return nothing
+# end
 
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
     N == zero(N) && return nothing
-    sum = zero(N)
-    for (offset, k) in zip(offsets(rule), kernel(rule))
-        @inbounds propagules = N * k
-        @inbounds add!(data[W], propagules, I .+ offset...)
-        sum += propagules
-    end
-    @inbounds sub!(data[W], sum, I...)
-    return nothing
-end
-
-# Define the custom OutwardsDispersalWithMask rule
-struct OutwardsDispersalWithMask{R,W,S<:Stencils.AbstractKernelStencil} <: SetNeighborhoodRule{R,W}
-    stencil::S
-end
-
-function OutwardsDispersalWithMask{R,W}(; kw...) where {R,W}
-    OutwardsDispersalWithMask{R,W}(DispersalKernel(; kw...))
-end
-
-@inline function applyrule!(data, rule::OutwardsDispersalWithMask{R,W}, N, I) where {R,W}
-    N == zero(N) && return nothing
     # Check if the current cell is masked, skip if it is
-    if !mask(data)[I...]
+    if rule.mask !== nothing && !rule.mask[I...]
         return nothing
     end
     sum = zero(N)
@@ -71,7 +64,7 @@ end
         target = I .+ offset
         # Check if the target cell is within bounds and not masked
         (target_mod, inbounds) = _inbounds(Reflect(), size(data[1]), target...)
-        if inbounds && mask(data)[target_mod...]
+        if inbounds && (rule.mask === nothing || rule.mask[target_mod...])
             @inbounds propagules = N * k  # Safe to use @inbounds after checks
             @inbounds add!(data[W], propagules, target_mod...)  # Safe to use @inbounds after checks
             sum += propagules

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -87,6 +87,9 @@ end
 
     # Check if the current cell is masked, skip if it is
     mask_data = if rule.mask_flag === NoMask() nothing else DynamicGrids.mask(data) end
+    if !isnothing(mask_data) && !mask_data[I...]
+        return nothing
+    end
     
     sum = zero(N)
     for (offset, k) in zip(offsets(rule), kernel(rule))
@@ -94,7 +97,7 @@ end
         inbounds = if isnothing(mask_data)    
             true
         else        
-            (target_mod, inbounds) = inbounds(data, target)
+            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
             mask_data[target_mod...]
         end
         if inbounds

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -6,7 +6,7 @@
     OutwardsPopulationDispersal{R,W}(; kw...)
 
 Implements deterministic dispersal from the current cell to populations in neighboring
-cells. Trying something
+cells. yup
 
 This will make sense ecologically where cell populations are large,
 otherwise a randomised kernel may be more suitable.
@@ -33,17 +33,22 @@ is occupied.
 Pass grid name `Symbol`s to `R` and `W` type parameters to use specific grids.
 """
 # Updated the OutwardsDispersal rule to include an optional mask
-struct OutwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil} <: SetNeighborhoodRule{R,W}
+# Updated struct definition with generic type M for mask
+struct OutwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil, M} <: SetNeighborhoodRule{R,W}
     stencil::S
     mask::M
 end
 
-function OutwardsDispersal{R,W}(stencil::S; mask=nothing) where {R,W,S<:Stencils.AbstractKernelStencil}
-    OutwardsDispersal{R,W,S}(stencil, mask)
+# Constructor function with the mask parameter
+function OutwardsDispersal{R,W,M}(stencil::S; mask::M=nothing) where {R,W,S<:Stencils.AbstractKernelStencil}
+    OutwardsDispersal{R,W,S,M}(stencil, mask)
 end
 
+# Constructor function without specifying stencil
 function OutwardsDispersal{R,W}(; kw...) where {R,W}
-    OutwardsDispersal{R,W}(DispersalKernel(; kw...))
+    stencil = DispersalKernel(; kw...)
+    mask = get(kw, :mask, nothing)
+    OutwardsDispersal{R,W,typeof(stencil),typeof(mask)}(stencil, mask)
 end
 
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -61,19 +61,14 @@ end
     if !isnothing(mask_data) && !mask_data[I...]
         return nothing
     end
-    
+
     sum = zero(N)
     for (offset, k) in zip(offsets(rule), kernel(rule))
         target = I .+ offset
-        inbounds = if isnothing(mask_data)    
-            true
-        else        
-            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
-            mask_data[target_mod...]
-        end
-        if inbounds
+        (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
+        if inbounds && (isnothing(mask_data) || mask_data[target_mod...])
             @inbounds propagules = N * k  
-            @inbounds add!(data[W], propagules, target...)  
+            @inbounds add!(data[W], propagules, target_mod...)  
             sum += propagules
         end
     end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -35,18 +35,19 @@ Pass grid name `Symbol`s to `R` and `W` type parameters to use specific grids.
 struct _Mask end
 const NoMask = nothing
 
-struct OutwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil} <: SetNeighborhoodRule{R,W}
+struct OutwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil, M} <: SetNeighborhoodRule{R,W}
     stencil::S
-    mask_flag::Union{_Mask, Nothing}
+    mask_flag::M
 end
 
-# Constructor for OutwardsDispersal
-function OutwardsDispersal{R,W}(stencil::S; mask_flag::Union{_Mask, Nothing}=NoMask) where {R,W,S<:Stencils.AbstractKernelStencil}
-    OutwardsDispersal{R,W,S}(stencil, mask_flag)
+# Constructors for OutwardsDispersal
+function OutwardsDispersal{R,W}(stencil::S; mask_flag=NoMask) where {R,W,S<:Stencils.AbstractKernelStencil}
+    OutwardsDispersal{R,W,S,typeof(mask_flag)}(stencil, mask_flag)
 end
 
-function OutwardsDispersal{R,W}(; kw...) where {R,W}
-    OutwardsDispersal{R,W}(DispersalKernel(; kw...))
+function OutwardsDispersal{R,W}(; mask_flag=NoMask, kw...) where {R,W}
+    stencil = DispersalKernel(; kw...)
+    OutwardsDispersal{R,W,typeof(stencil),typeof(mask_flag)}(stencil, mask_flag)
 end
 
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
@@ -71,3 +72,50 @@ end
     @inbounds sub!(data[W], sum, I...)
     return nothing
 end
+
+# @inline function applyrule(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
+#     applyrule!(data, rule, N, I)
+# end
+
+################# TESTING #################
+# Define a mask
+mask_data = fill(true, 10, 10)
+for i in 3:9 
+    mask_data[2, i] = false
+    mask_data[3, i] = false
+    mask_data[4, i] = false
+    mask_data[5, i] = false
+    mask_data[6, i] = false
+    mask_data[7, i] = false
+    mask_data[8, i] = false
+end
+
+# Create OutwardsDispersal with and without a mask
+outdisp_with_mask = OutwardsDispersal(
+    formulation=ExponentialKernel(λ=0.0125),
+    distancemethod=AreaToArea(30),
+    mask_flag=_Mask()
+)
+
+outdisp_without_mask = OutwardsDispersal(
+    formulation=ExponentialKernel(λ=0.0125),
+    distancemethod=AreaToArea(30)
+)
+
+# Initialize the simulation grid
+init = fill(100.0, (10,10))
+init[5,5] = 0.0
+
+# Create ruleset and outputs
+rule_with_mask = Ruleset(outdisp_with_mask; boundary=Reflect())
+rule_without_mask = Ruleset(outdisp_without_mask; boundary=Reflect())
+
+# Run the simulation with a mask
+out_with_mask = ArrayOutput(init; tspan=1:100, mask=mask_data)
+a = sim!(out_with_mask, rule_with_mask)
+a[1][5,5]
+a[2][5,5]
+# Run the simulation without a mask
+out_without_mask = ArrayOutput(init; tspan=1:100)
+sim!(out_without_mask, rule_without_mask)
+

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -29,7 +29,8 @@ is occupied.
     Default is 1.0.
 - `distancemethod`: [`DistanceMethod`](@ref) object for calculating distance between cells.
     The default is [`CentroidToCentroid`](@ref).
-- `mask_flag`: Use `Mask()` to apply masking or `NoMask()` to ignore masking. Default is `NoMask`.
+- `mask_flag`: Use `Mask()` to apply masking. Default is `NoMask()`. Using Mask() will cause
+    a drop in performance.
 
 Pass grid name `Symbol`s to `R` and `W` type parameters to use specific grids.
 """
@@ -51,36 +52,6 @@ function OutwardsDispersal{R,W}(; mask_flag::Union{Mask, NoMask}=NoMask(), kw...
     stencil = DispersalKernel(; kw...)
     OutwardsDispersal{R,W,typeof(stencil),typeof(mask_flag)}(stencil, mask_flag)
 end
-
-# @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
-#     N == zero(N) && return nothing
-#     mask_data = rule.mask_flag === NoMask() ? nothing : DynamicGrids.mask(data)
-#     sum = zero(N)
-
-#     if isnothing(mask_data)
-#         # If there is no mask
-#         for (offset, k) in zip(offsets(rule), kernel(rule))
-#             @inbounds propagules = N * k
-#             @inbounds add!(data[W], propagules, I .+ offset...)
-#             sum += propagules
-#         end
-#     elseif !mask_data[I...]
-#         # If there is a mask and the source cell is masked
-#         return nothing
-#     else
-#         for (offset, k) in zip(offsets(rule), kernel(rule))
-#             (target_mod, inbounds) = inbounds(data, I .+ offset)
-#             if inbounds && mask_data[target_mod...]
-#                 @inbounds propagules = N * k  
-#                 @inbounds add!(data[W], propagules, target_mod...)  
-#                 sum += propagules
-#             end
-#         end
-#     end
-
-#     @inbounds sub!(data[W], sum, I...)
-#     return nothing
-# end
 
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
     N == zero(N) && return nothing

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -39,17 +39,26 @@ function OutwardsDispersal{R,W}(; kw...) where {R,W}
     OutwardsDispersal{R,W}(DispersalKernel(; kw...))
 end
 
-# @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
-#     N == zero(N) && return nothing
-#     sum = zero(N)
-#     for (offset, k) in zip(offsets(rule), kernel(rule))
-#         @inbounds propagules = N * k
-#         @inbounds add!(data[W], propagules, I .+ offset...)
-#         sum += propagules
-#     end
-#     @inbounds sub!(data[W], sum, I...)
-#     return nothing
-# end
+@inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
+    N == zero(N) && return nothing
+    sum = zero(N)
+    for (offset, k) in zip(offsets(rule), kernel(rule))
+        @inbounds propagules = N * k
+        @inbounds add!(data[W], propagules, I .+ offset...)
+        sum += propagules
+    end
+    @inbounds sub!(data[W], sum, I...)
+    return nothing
+end
+
+# Define the custom OutwardsDispersalWithMask rule
+struct OutwardsDispersalWithMask{R,W,S<:Stencils.AbstractKernelStencil} <: SetNeighborhoodRule{R,W}
+    stencil::S
+end
+
+function OutwardsDispersalWithMask{R,W}(; kw...) where {R,W}
+    OutwardsDispersalWithMask{R,W}(DispersalKernel(; kw...))
+end
 
 @inline function applyrule!(data, rule::OutwardsDispersalWithMask{R,W}, N, I) where {R,W}
     N == zero(N) && return nothing

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -54,14 +54,15 @@ function OutwardsDispersal{R,W}(; mask_flag::Union{Mask, NoMask}=NoMask(), kw...
 end
 
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
-    if typeof(init(data)[1]) == Matrix{MyStructs256{Float64}} 
+    if typeof(DynamicGrids.init(data)[1]) == Matrix{MyStructs256{Float64}} 
+
         N == zero(MyStructs256{Float64}) && return nothing
 
-    # Check if the current cell is masked, skip if it is
-    mask_data = if rule.mask_flag === NoMask() nothing else DynamicGrids.mask(data) end
-    if !isnothing(mask_data) && !mask_data[I...]
+        # Check if the current cell is masked, skip if it is
+        mask_data = if rule.mask_flag === NoMask() nothing else DynamicGrids.mask(data) end
+        if !isnothing(mask_data) && !mask_data[I...]
         return nothing
-    end
+        end
     
     sum = zero(N)
     for (offset, k) in zip(offsets(rule), kernel(rule))

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -49,7 +49,7 @@ end
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
     N == zero(N) && return nothing
     # Check if the current cell is masked, skip if it is
-    if rule.mask !== nothing && !rule.mask[I...]
+    !isnothing(rule.mask) && !rule.mask[I...]
         return nothing
     end
     sum = zero(N)

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -6,7 +6,7 @@
     OutwardsPopulationDispersal{R,W}(; kw...)
 
 Implements deterministic dispersal from the current cell to populations in neighboring
-cells. hello
+cells. ups
 
 This will make sense ecologically where cell populations are large,
 otherwise a randomised kernel may be more suitable.

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -6,7 +6,7 @@
     OutwardsPopulationDispersal{R,W}(; kw...)
 
 Implements deterministic dispersal from the current cell to populations in neighboring
-cells. Hey there
+cells.
 
 This will make sense ecologically where cell populations are large,
 otherwise a randomised kernel may be more suitable.
@@ -32,7 +32,7 @@ is occupied.
 
 Pass grid name `Symbol`s to `R` and `W` type parameters to use specific grids.
 """
-# Update the OutwardsDispersal rule to include an optional mask
+# Updated the OutwardsDispersal rule to include an optional mask
 struct OutwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil} <: SetNeighborhoodRule{R,W}
     stencil::S
     mask::Union{Nothing, Array{Bool}}  # Add an optional mask parameter
@@ -44,13 +44,6 @@ end
 
 function OutwardsDispersal{R,W}(; kw...) where {R,W}
     OutwardsDispersal{R,W}(DispersalKernel(; kw...))
-end
-
-# Utility function to check if a target is within bounds considering boundary conditions
-@inline function _inbounds(boundary::BoundaryCondition, size::Tuple, i1, i2)
-    a, inbounds_a = _inbounds(boundary, size[1], i1)
-    b, inbounds_b = _inbounds(boundary, size[2], i2)
-    (a, b), inbounds_a & inbounds_b
 end
 
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
@@ -65,11 +58,11 @@ end
         # Check if the target cell is within bounds and not masked
         (target_mod, inbounds) = _inbounds(Reflect(), size(data[1]), target...)
         if inbounds && (rule.mask === nothing || rule.mask[target_mod...])
-            @inbounds propagules = N * k  # Safe to use @inbounds after checks
-            @inbounds add!(data[W], propagules, target_mod...)  # Safe to use @inbounds after checks
+            @inbounds propagules = N * k  
+            @inbounds add!(data[W], propagules, target_mod...)  
             sum += propagules
         end
     end
-    @inbounds sub!(data[W], sum, I...)  # Safe to use @inbounds after checks
+    @inbounds sub!(data[W], sum, I...)
     return nothing
 end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -66,13 +66,9 @@ end
     if isnothing(mask_data)
         # If there is no mask
         for (offset, k) in zip(offsets(rule), kernel(rule))
-            target = I .+ offset
-            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
-            if inbounds
-                @inbounds propagules = N * k  
-                @inbounds add!(data[W], propagules, target_mod...)  
-                sum += propagules
-            end
+            @inbounds propagules = N * k
+            @inbounds add!(data[W], propagules, I .+ offset...)
+            sum += propagules
         end
     else
         # If there is a mask

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -49,20 +49,19 @@ end
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
     N == zero(N) && return nothing
     # Check if the current cell is masked, skip if it is
-    !isnothing(rule.mask) && !rule.mask[I...]
+    if isnothing(rule.mask) || rule.mask[I...]
         return nothing
     end
     sum = zero(N)
     for (offset, k) in zip(offsets(rule), kernel(rule))
         target = I .+ offset
-        # Check if the target cell is within bounds and not masked
         (target_mod, inbounds) = _inbounds(Reflect(), size(data[1]), target...)
-        if inbounds && (rule.mask === nothing || rule.mask[target_mod...])
+        if inbounds && (isnothing(rule.mask) || mask(data)[target_mod...])
             @inbounds propagules = N * k  
             @inbounds add!(data[W], propagules, target_mod...)  
             sum += propagules
         end
-    end
+    end 
     @inbounds sub!(data[W], sum, I...)
     return nothing
 end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -87,18 +87,15 @@ end
 
     # Check if the current cell is masked, skip if it is
     mask_data = if rule.mask_flag === NoMask() nothing else DynamicGrids.mask(data) end
-    if !isnothing(mask_data) && !mask_data[I...]
-        return nothing
-    end
-
+    
     sum = zero(N)
     for (offset, k) in zip(offsets(rule), kernel(rule))
         target = I .+ offset
-        inbounds = if isnothing(mask_data)    
-            true
-        else        
-            (target_mod, inbounds) = inbounds(data, target)
-            mask_data[target_mod...]
+        if isnothing(mask_data)
+            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
+        else
+            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
+            inbounds = inbounds && mask_data[target_mod...]
         end
         if inbounds
             propagules = N * k  

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -91,15 +91,15 @@ end
     sum = zero(N)
     for (offset, k) in zip(offsets(rule), kernel(rule))
         target = I .+ offset
-        if isnothing(mask_data)
-            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
-        else
-            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
-            inbounds = inbounds && mask_data[target_mod...]
+        inbounds = if isnothing(mask_data)    
+            true
+        else        
+            (target_mod, inbounds) = inbounds(data, target)
+            mask_data[target_mod...]
         end
         if inbounds
             propagules = N * k  
-            @inbounds add!(data[W], propagules, target_mod...)  
+            @inbounds add!(data[W], propagules, target...)  
             sum += propagules
         end
     end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -35,7 +35,7 @@ Pass grid name `Symbol`s to `R` and `W` type parameters to use specific grids.
 # Updated the OutwardsDispersal rule to include an optional mask
 struct OutwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil} <: SetNeighborhoodRule{R,W}
     stencil::S
-    mask::Union{Nothing, Array{Bool}}  # Add an optional mask parameter
+    mask::M
 end
 
 function OutwardsDispersal{R,W}(stencil::S; mask=nothing) where {R,W,S<:Stencils.AbstractKernelStencil}

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -86,7 +86,7 @@ end
     N == zero(N) && return nothing
 
     # Check if the current cell is masked, skip if it is
-    mask_data = if rule.mask_flag === NoMask() nothing else mask(data) end
+    mask_data = if rule.mask_flag === NoMask() nothing else DynamicGrids.mask(data) end
     if !isnothing(mask_data) && !mask_data[I...]
         return nothing
     end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -6,7 +6,7 @@
     OutwardsPopulationDispersal{R,W}(; kw...)
 
 Implements deterministic dispersal from the current cell to populations in neighboring
-cells.
+cells. Trying something
 
 This will make sense ecologically where cell populations are large,
 otherwise a randomised kernel may be more suitable.

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -73,8 +73,7 @@ end
     else
         # If there is a mask
         for (offset, k) in zip(offsets(rule), kernel(rule))
-            target = I .+ offset
-            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
+            (target_mod, inbounds) = DynamicGrids.inbounds(data, I .+ offset)
             if inbounds && mask_data[target_mod...]
                 @inbounds propagules = N * k  
                 @inbounds add!(data[W], propagules, target_mod...)  

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -62,15 +62,31 @@ end
     end
     
     sum = zero(N)
-    for (offset, k) in zip(offsets(rule), kernel(rule))
-        target = I .+ offset
-        (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
-        if inbounds && (isnothing(mask_data) || mask_data[target_mod...])
-            @inbounds propagules = N * k  
-            @inbounds add!(data[W], propagules, target_mod...)  
-            sum += propagules
+
+    if isnothing(mask_data)
+        # If there is no mask
+        for (offset, k) in zip(offsets(rule), kernel(rule))
+            target = I .+ offset
+            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
+            if inbounds
+                @inbounds propagules = N * k  
+                @inbounds add!(data[W], propagules, target_mod...)  
+                sum += propagules
+            end
+        end
+    else
+        # If there is a mask
+        for (offset, k) in zip(offsets(rule), kernel(rule))
+            target = I .+ offset
+            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
+            if inbounds && mask_data[target_mod...]
+                @inbounds propagules = N * k  
+                @inbounds add!(data[W], propagules, target_mod...)  
+                sum += propagules
+            end
         end
     end
+
     @inbounds sub!(data[W], sum, I...)
     return nothing
 end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -6,7 +6,7 @@
     OutwardsPopulationDispersal{R,W}(; kw...)
 
 Implements deterministic dispersal from the current cell to populations in neighboring
-cells. ups
+cells.
 
 This will make sense ecologically where cell populations are large,
 otherwise a randomised kernel may be more suitable.

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -54,34 +54,6 @@ function OutwardsDispersal{R,W}(; mask_flag::Union{Mask, NoMask}=NoMask(), kw...
 end
 
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
-    if typeof(DynamicGrids.init(data)[1]) == Matrix{MyStructs256{Float64}} 
-
-        N == zero(MyStructs256{Float64}) && return nothing
-
-        # Check if the current cell is masked, skip if it is
-        mask_data = if rule.mask_flag === NoMask() nothing else DynamicGrids.mask(data) end
-        if !isnothing(mask_data) && !mask_data[I...]
-        return nothing
-        end
-    
-    sum = zero(N)
-    for (offset, k) in zip(offsets(rule), kernel(rule))
-        target = I .+ offset
-        inbounds = if isnothing(mask_data)    
-            true
-        else        
-            (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
-            mask_data[target_mod...]
-        end
-        if inbounds
-            @inbounds propagules = N * k  
-            @inbounds add!(data[W], propagules, target...)  
-            sum += propagules
-        end
-    end
-    @inbounds sub!(data[W], sum, I...)
-    return nothing
-    else    
     N == zero(N) && return nothing
 
     # Check if the current cell is masked, skip if it is
@@ -107,5 +79,4 @@ end
     end
     @inbounds sub!(data[W], sum, I...)
     return nothing
-    end
 end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -94,7 +94,7 @@ end
     sum = zero(N)
     for (offset, k) in zip(offsets(rule), kernel(rule))
         target = I .+ offset
-        (target_mod, inbounds) = inbounds(data, target)
+        (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
         if inbounds && (isnothing(mask_data) || mask_data[target_mod...])
             @inbounds propagules = N * k  
             @inbounds add!(data[W], propagules, target_mod...)  

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -34,72 +34,20 @@ is occupied.
 Pass grid name `Symbol`s to `R` and `W` type parameters to use specific grids.
 """
 
-struct Mask end
-struct NoMask end
-
-struct OutwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil, M} <: SetNeighborhoodRule{R,W}
-    stencil::S
-    mask_flag::M
+struct OutwardsDispersal{R,W,N<:AbstractKernelNeighborhood} <: SetNeighborhoodRule{R,W}
+    neighborhood::N
 end
-
-# Constructors for OutwardsDispersal
-function OutwardsDispersal{R,W}(stencil::S; mask_flag::Union{Mask, NoMask}=NoMask()) where {R,W,S<:Stencils.AbstractKernelStencil}
-    OutwardsDispersal{R,W,S,typeof(mask_flag)}(stencil, mask_flag)
+function OutwardsDispersal{R,W}(; kw...) where {R,W}
+    OutwardsDispersal{R,W}(DispersalKernel(; kw...))
 end
-
-function OutwardsDispersal{R,W}(; mask_flag::Union{Mask, NoMask}=NoMask(), kw...) where {R,W}
-    stencil = DispersalKernel(; kw...)
-    OutwardsDispersal{R,W,typeof(stencil),typeof(mask_flag)}(stencil, mask_flag)
-end
-
-# @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
-#     N == zero(N) && return nothing
-#     mask_data = rule.mask_flag === NoMask() ? nothing : DynamicGrids.mask(data)
-#     sum = zero(N)
-
-#     if isnothing(mask_data)
-#         # If there is no mask
-#         for (offset, k) in zip(offsets(rule), kernel(rule))
-#             @inbounds propagules = N * k
-#             @inbounds add!(data[W], propagules, I .+ offset...)
-#             sum += propagules
-#         end
-#     elseif !mask_data[I...]
-#         # If there is a mask and the source cell is masked
-#         return nothing
-#     else
-#         for (offset, k) in zip(offsets(rule), kernel(rule))
-#             (target_mod, inbounds) = inbounds(data, I .+ offset)
-#             if inbounds && mask_data[target_mod...]
-#                 @inbounds propagules = N * k  
-#                 @inbounds add!(data[W], propagules, target_mod...)  
-#                 sum += propagules
-#             end
-#         end
-#     end
-
-#     @inbounds sub!(data[W], sum, I...)
-#     return nothing
-# end
 
 @inline function applyrule!(data, rule::OutwardsDispersal{R,W}, N, I) where {R,W}
     N == zero(N) && return nothing
-
-    # Check if the current cell is masked, skip if it is
-    mask_data = if rule.mask_flag === NoMask() nothing else DynamicGrids.mask(data) end
-    if !isnothing(mask_data) && !mask_data[I...]
-        return nothing
-    end
-
     sum = zero(N)
     for (offset, k) in zip(offsets(rule), kernel(rule))
-        target = I .+ offset
-        (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
-        if inbounds && (isnothing(mask_data) || mask_data[target_mod...])
-            @inbounds propagules = N * k  
-            @inbounds add!(data[W], propagules, target_mod...)  
-            sum += propagules
-        end
+        @inbounds propagules = N * k
+        @inbounds add!(data[W], propagules, I .+ offset...)
+        sum += propagules
     end
     @inbounds sub!(data[W], sum, I...)
     return nothing

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -101,7 +101,7 @@ end
             mask_data[target_mod...]
         end
         if inbounds
-            propagules = N * k  
+            @inbounds propagules = N * k  
             @inbounds add!(data[W], propagules, target...)  
             sum += propagules
         end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -94,9 +94,14 @@ end
     sum = zero(N)
     for (offset, k) in zip(offsets(rule), kernel(rule))
         target = I .+ offset
-        (target_mod, inbounds) = DynamicGrids.inbounds(data, target)
-        if inbounds && (isnothing(mask_data) || mask_data[target_mod...])
-            @inbounds propagules = N * k  
+        inbounds = if isnothing(mask_data)    
+            true
+        else        
+            (target_mod, inbounds) = inbounds(data, target)
+            mask_data[target_mod...]
+        end
+        if inbounds
+            propagules = N * k  
             @inbounds add!(data[W], propagules, target_mod...)  
             sum += propagules
         end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -29,8 +29,10 @@ is occupied.
     Default is 1.0.
 - `distancemethod`: [`DistanceMethod`](@ref) object for calculating distance between cells.
     The default is [`CentroidToCentroid`](@ref).
-- `mask_flag`: Use `Mask()` to apply masking. Default is `NoMask()`. Using Mask() will cause
-    a drop in performance.
+- `mask_flag`: The default setting is `NoMask()`. Use `Mask()` to indicate that the grid is 
+    masked, enabling the rule to perform boundary checking at mask edges. Not using 
+    `Mask()` on a masked grid may result in the loss of individuals at the edges, but it comes
+    at a performance cost.
 
 Pass grid name `Symbol`s to `R` and `W` type parameters to use specific grids.
 """

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -56,7 +56,7 @@ end
     N == zero(N) && return nothing
     
     # Check if the current cell is masked, skip if it is
-    mask_data = if rule.mask_flag === NoMask() nothing else DynamicGrids.mask(data) end
+    mask_data = rule.mask_flag === NoMask() ? nothing : DynamicGrids.mask(data)
     if !isnothing(mask_data) && !mask_data[I...]
         return nothing
     end

--- a/src/kernel/outwards.jl
+++ b/src/kernel/outwards.jl
@@ -6,7 +6,7 @@
     OutwardsPopulationDispersal{R,W}(; kw...)
 
 Implements deterministic dispersal from the current cell to populations in neighboring
-cells.
+cells. Hey there
 
 This will make sense ecologically where cell populations are large,
 otherwise a randomised kernel may be more suitable.

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -210,6 +210,6 @@ end
     output_without_mask = ArrayOutput(init; tspan=1:1000, mask=mask_data)
     b = sim!(output_without_mask, rule_without_mask)
 
-    @test sum(b[1]) !≈ sum(b[1000]) #= Floating error should be larger than 1.0
+    @test sum(b[1]) > sum(b[1000]) #= Floating error should be larger than 1.0
     because this does not identify the mask properly =#
 end

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -198,13 +198,13 @@ end
     output_with_mask = ArrayOutput(init; tspan=1:1000, mask=mask_data)
     a = sim!(output_with_mask, rule_with_mask)
     
-    @test sum(a[1]) ≈ sum(a[1000]) # Floating error should be smaller than 1.0
+    @test sum(a[1]) ≈ sum(a[1000]) # Floating error should be close to zero
 
     # Run the simulation without a mask to check default works fine
     output_without_mask = ArrayOutput(init; tspan=1:1000)
     b = sim!(output_without_mask, rule_without_mask)
 
-    @test sum(b[1]) ≈ sum(b[1000]) # Floating error should be smaller than 1.0
+    @test sum(b[1]) ≈ sum(b[1000]) # Floating error should be close to zero
 
     # Run the simulation with a mask but outdisp_without_mask
     output_without_mask = ArrayOutput(init; tspan=1:1000, mask=mask_data)


### PR DESCRIPTION
Hey there again :)

I opened the PR to discuss a "small?" implementation of masked boundary checks in OutwardsDispersal. I haven't had much success yet but we're on it :) I've tried to modify OutwardsDispersal such that it can hold an optional mask:
```
struct OutwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil} <: SetNeighborhoodRule{R,W}
    stencil::S
    mask::Union{Nothing, Array{Bool}}  # Add an optional mask parameter
end
```
And then modified its applyrule! so it discards cells outside of the mask.
 
Perhaps I instead should create a brand new OutwardsDispersalWithMask to keep them separate but since I don't know what other parts of the "family" packages are related with these rules, this feels more tedious to build.

Just for the sake of understanding the package behaviour: 
- How come InwardsDispersal works fine while not being defined anywhere in the package nor DG/Stencils/etc? Like this is all it's written:
```
struct InwardsDispersal{R,W,S<:Stencils.AbstractKernelStencil} <: NeighborhoodRule{R,W}
    stencil::S
end
function InwardsDispersal{R,W}(; kw...) where {R,W}
    InwardsDispersal{R,W}(DispersalKernel(; kw...))
end

@inline applyrule(data, rule::InwardsDispersal, N, I) = kernelproduct(rule)
```
I know what `kernelproduct() ` is used for, but where did you define its method for an InwardsDispersal rule? 

Edit: Btw, just to know. Are tests passing for you? Because I could not pass them even before making any modification.